### PR TITLE
Update README.md to include psutil requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,19 @@
 This extension provides a quick way to browse to local http or https listeners instead of fishing the specific ports in your browser history.
 
 ![ulauncher-local-listeners extension screenshot](screenshot.png)
+
+## Requirements
+This extension requires package `psutil` for python2.
+To install:
+
+```
+  pip install psutil
+```
+
+or
+
+```
+  pip2 install psutil
+```
+
+for Arch users.


### PR DESCRIPTION
This extension did not work without python2 package `psutil`.
I included this requirement in `README.md`.